### PR TITLE
Created a new parser for legacy UNECE message specifications (all up to version D99A)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
             "postversion": "git push && git push -- tags"
       },
       "devDependencies": {
+            "@initics/tsm": "^1.0.2",
             "@types/events": "3.0.0",
             "@types/htmlparser2": "^3.10.1",
             "@types/jasmine": "^3.5.11",

--- a/spec/data/d99a_invoic_s.html
+++ b/spec/data/d99a_invoic_s.html
@@ -1,0 +1,308 @@
+
+<!-- saved from url=(0061)https://service.unece.org/trade/untdid/d99a/trmd/invoic_s.htm -->
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<!-- --- This document was created by Viorel Iordache - UN/ECE ------->
+<title>UNTDID - D.99A Segment Table of INVOIC</title><script data-dapp-detection="">!function(){let e=!1;function n(){if(!e){const n=document.createElement("meta");n.name="dapp-detected",document.head.appendChild(n),e=!0}}if(window.hasOwnProperty("ethereum")){if(window.__disableDappDetectionInsertion=!0,void 0===window.ethereum)return;n()}else{var t=window.ethereum;Object.defineProperty(window,"ethereum",{configurable:!0,enumerable:!1,set:function(e){window.__disableDappDetectionInsertion||n(),t=e},get:function(){if(!window.__disableDappDetectionInsertion){const e=arguments.callee;e&&e.caller&&e.caller.toString&&-1!==e.caller.toString().indexOf("getOwnPropertyNames")||n()}return t}})}}();</script></head>
+<body bgcolor="ffffff"><pre>
+We recommend to view this page using <a href="https://service.unece.org/trade/untdid/texts/linedraw.zip">MS LineDraw</a> as fixed font in your browsers' preferences
+
+<b>4.3   Message structure</b>
+
+4.3.1  <b>Segment table
+
+Pos   Tag Name                                 S   R</b>
+
+           HEADER SECTION
+
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0010">0010</a>   <a href="http://www.gefeg.com/jswg/">UNH</a> Message header                            M   1     
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0020">0020</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdbgm.htm">BGM</a> Beginning of message                      M   1     
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0030">0030</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          M   35    
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0040">0040</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdpai.htm">PAI</a> Payment instructions                      C   1     
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0050">0050</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdali.htm">ALI</a> Additional information                    C   5     
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0060">0060</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdimd.htm">IMD</a> Item description                          C   1     
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0070">0070</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdftx.htm">FTX</a> Free text                                 C   99    
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0080">0080</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdloc.htm">LOC</a> Place/location identification             C   10    
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0090">0090</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdgis.htm">GIS</a> General indicator                         C   10    
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0100">0100</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddgs.htm">DGS</a> Dangerous goods                           C   1     
+
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0110">0110</a> *     ����� Segment group 1  ������������������ C   99999������Ŀ
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0120">0120</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrff.htm">RFF</a> Reference                                 M   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0130">0130</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0140">0140</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdgir.htm">GIR</a> Related identification numbers            C   5           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0150">0150</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdloc.htm">LOC</a> Place/location identification             C   2           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0160">0160</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmea.htm">MEA</a> Measurements                              C   5           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0170">0170</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdqty.htm">QTY</a> Quantity                                  C   2           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0180">0180</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdftx.htm">FTX</a> Free text                                 C   5           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0190">0190</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmoa.htm">MOA</a> Monetary amount                           C   2������������
+
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0200">0200</a>       ����� Segment group 2  ������������������ C   99���������Ŀ
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0210">0210</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdnad.htm">NAD</a> Name and address                          M   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0220">0220</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdloc.htm">LOC</a> Place/location identification             C   25          �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0230">0230</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdfii.htm">FII</a> Financial institution information         C   5           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0240">0240</a> + <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmoa.htm">MOA</a> Monetary amount                           C   99          �
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0250">0250</a>       ����� Segment group 3  ������������������ C   9999������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0260">0260</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrff.htm">RFF</a> Reference                                 M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0270">0270</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5����������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0280">0280</a>       ����� Segment group 4  ������������������ C   5���������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0290">0290</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddoc.htm">DOC</a> Document/message details                  M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0300">0300</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5����������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0310">0310</a>       ����� Segment group 5  ������������������ C   5���������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0320">0320</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdcta.htm">CTA</a> Contact information                       M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0330">0330</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdcom.htm">COM</a> Communication contact                     C   5������������
+
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0340">0340</a>       ����� Segment group 6  ������������������ C   5����������Ŀ
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0350">0350</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdtax.htm">TAX</a> Duty/tax/fee details                      M   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0360">0360</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmoa.htm">MOA</a> Monetary amount                           C   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0370">0370</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdloc.htm">LOC</a> Place/location identification             C   5������������
+
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0380">0380</a>       ����� Segment group 7  ������������������ C   99���������Ŀ
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0390">0390</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdcux.htm">CUX</a> Currencies                                M   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0400">0400</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5������������
+
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0410">0410</a>       ����� Segment group 8  ������������������ C   10���������Ŀ
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0420">0420</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdpat.htm">PAT</a> Payment terms basis                       M   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0430">0430</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0440">0440</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdpcd.htm">PCD</a> Percentage details                        C   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0450">0450</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmoa.htm">MOA</a> Monetary amount                           C   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0460">0460</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdpai.htm">PAI</a> Payment instructions                      C   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0470">0470</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdfii.htm">FII</a> Financial institution information         C   1������������
+
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0480">0480</a>       ����� Segment group 9  ������������������ C   10���������Ŀ
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0490">0490</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdtdt.htm">TDT</a> Details of transport                      M   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0500">0500</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdtsr.htm">TSR</a> Transport service requirements            C   1           �
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0510">0510</a>       ����� Segment group 10 ������������������ C   10��������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0520">0520</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdloc.htm">LOC</a> Place/location identification             M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0530">0530</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5����������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0540">0540</a>       ����� Segment group 11 ������������������ C   9999������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0550">0550</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrff.htm">RFF</a> Reference                                 M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0560">0560</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5������������
+
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0570">0570</a>       ����� Segment group 12 ������������������ C   5����������Ŀ
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0580">0580</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdtod.htm">TOD</a> Terms of delivery or transport            M   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0590">0590</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdloc.htm">LOC</a> Place/location identification             C   2������������
+
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0600">0600</a>       ����� Segment group 13 ������������������ C   99���������Ŀ
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0610">0610</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdeqd.htm">EQD</a> Equipment details                         M   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0620">0620</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdsel.htm">SEL</a> Seal number                               C   9������������
+
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0630">0630</a>       ����� Segment group 14 ������������������ C   1000�������Ŀ
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0640">0640</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdpac.htm">PAC</a> Package                                   M   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0650">0650</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmea.htm">MEA</a> Measurements                              C   5           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0660">0660</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdeqd.htm">EQD</a> Equipment details                         C   1           �
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0670">0670</a>       ����� Segment group 15 ������������������ C   5���������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0680">0680</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdpci.htm">PCI</a> Package identification                    M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0690">0690</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrff.htm">RFF</a> Reference                                 C   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0700">0700</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0710">0710</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdgin.htm">GIN</a> Goods identity number                     C   5������������
+
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0720">0720</a>       ����� Segment group 16 ������������������ C   9999�������Ŀ
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0730">0730</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdalc.htm">ALC</a> Allowance or charge                       M   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0740">0740</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdali.htm">ALI</a> Additional information                    C   5           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0750">0750</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdftx.htm">FTX</a> Free text                                 C   1           �
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0760">0760</a>       ����� Segment group 17 ������������������ C   5���������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0770">0770</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrff.htm">RFF</a> Reference                                 M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0780">0780</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5����������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0790">0790</a>       ����� Segment group 18 ������������������ C   1���������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0800">0800</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdqty.htm">QTY</a> Quantity                                  M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0810">0810</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrng.htm">RNG</a> Range details                             C   1����������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0820">0820</a>       ����� Segment group 19 ������������������ C   1���������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0830">0830</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdpcd.htm">PCD</a> Percentage details                        M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0840">0840</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrng.htm">RNG</a> Range details                             C   1����������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0850">0850</a>       ����� Segment group 20 ������������������ C   2���������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0860">0860</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmoa.htm">MOA</a> Monetary amount                           M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0870">0870</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrng.htm">RNG</a> Range details                             C   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0880">0880</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdcux.htm">CUX</a> Currencies                                C   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0890">0890</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   1����������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0900">0900</a>       ����� Segment group 21 ������������������ C   1���������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0910">0910</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrte.htm">RTE</a> Rate details                              M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0920">0920</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrng.htm">RNG</a> Range details                             C   1����������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0930">0930</a>       ����� Segment group 22 ������������������ C   5���������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0940">0940</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdtax.htm">TAX</a> Duty/tax/fee details                      M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0950">0950</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmoa.htm">MOA</a> Monetary amount                           C   1������������
+
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0960">0960</a>       ����� Segment group 23 ������������������ C   100��������Ŀ
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0970">0970</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrcs.htm">RCS</a> Requirements and conditions               M   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0980">0980</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrff.htm">RFF</a> Reference                                 C   5           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#0990">0990</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1000">1000</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdftx.htm">FTX</a> Free text                                 C   5������������
+
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1010">1010</a>       ����� Segment group 24 ������������������ C   1����������Ŀ
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1020">1020</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdajt.htm">AJT</a> Adjustment details                        M   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1030">1030</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdftx.htm">FTX</a> Free text                                 C   5������������
+
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1040">1040</a>       ����� Segment group 25 ������������������ C   1����������Ŀ
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1050">1050</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdinp.htm">INP</a> Parties and instruction                   M   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1060">1060</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdftx.htm">FTX</a> Free text                                 C   5������������
+
+           DETAIL SECTION
+
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1070">1070</a>       ����� Segment group 26 ������������������ C   9999999����Ŀ
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1080">1080</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdlin.htm">LIN</a> Line item                                 M   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1090">1090</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdpia.htm">PIA</a> Additional product id                     C   25          �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1100">1100</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdimd.htm">IMD</a> Item description                          C   10          �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1110">1110</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmea.htm">MEA</a> Measurements                              C   5           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1120">1120</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdqty.htm">QTY</a> Quantity                                  C   5           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1130">1130</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdpcd.htm">PCD</a> Percentage details                        C   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1140">1140</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdali.htm">ALI</a> Additional information                    C   5           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1150">1150</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   35          �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1160">1160</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdgin.htm">GIN</a> Goods identity number                     C   1000        �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1170">1170</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdgir.htm">GIR</a> Related identification numbers            C   1000        �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1180">1180</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdqvr.htm">QVR</a> Quantity variances                        C   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1190">1190</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdeqd.htm">EQD</a> Equipment details                         C   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1200">1200</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdftx.htm">FTX</a> Free text                                 C   99          �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1210">1210</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddgs.htm">DGS</a> Dangerous goods                           C   1           �
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1220">1220</a>       ����� Segment group 27 ������������������ C   99��������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1230">1230</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmoa.htm">MOA</a> Monetary amount                           M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1240">1240</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdcux.htm">CUX</a> Currencies                                C   1����������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1250">1250</a>       ����� Segment group 28 ������������������ C   10��������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1260">1260</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdpat.htm">PAT</a> Payment terms basis                       M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1270">1270</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1280">1280</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdpcd.htm">PCD</a> Percentage details                        C   99         ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1290">1290</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmoa.htm">MOA</a> Monetary amount                           C   1����������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1300">1300</a>       ����� Segment group 29 ������������������ C   25��������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1310">1310</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdpri.htm">PRI</a> Price details                             M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1320">1320</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdcux.htm">CUX</a> Currencies                                C   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1330">1330</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdapr.htm">APR</a> Additional price information              C   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1340">1340</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrng.htm">RNG</a> Range details                             C   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1350">1350</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5����������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1360">1360</a>       ����� Segment group 30 ������������������ C   10��������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1370">1370</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrff.htm">RFF</a> Reference                                 M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1380">1380</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5����������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1390">1390</a>       ����� Segment group 31 ������������������ C   10��������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1400">1400</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdpac.htm">PAC</a> Package                                   M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1410">1410</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmea.htm">MEA</a> Measurements                              C   10         ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1420">1420</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdeqd.htm">EQD</a> Equipment details                         C   1          ��
+                                                                    ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1430">1430</a>       ����� Segment group 32 ������������������ C   10�������Ŀ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1440">1440</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdpci.htm">PCI</a> Package identification                    M   1         ���
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1450">1450</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrff.htm">RFF</a> Reference                                 C   1         ���
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1460">1460</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5         ���
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1470">1470</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdgin.htm">GIN</a> Goods identity number                     C   10���������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1480">1480</a>       ����� Segment group 33 ������������������ C   9999������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1490">1490</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdloc.htm">LOC</a> Place/location identification             M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1500">1500</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdqty.htm">QTY</a> Quantity                                  C   100        ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1510">1510</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5����������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1520">1520</a>       ����� Segment group 34 ������������������ C   99��������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1530">1530</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdtax.htm">TAX</a> Duty/tax/fee details                      M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1540">1540</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmoa.htm">MOA</a> Monetary amount                           C   2          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1550">1550</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdloc.htm">LOC</a> Place/location identification             C   5����������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1560">1560</a>       ����� Segment group 35 ������������������ C   99��������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1570">1570</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdnad.htm">NAD</a> Name and address                          M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1580">1580</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdloc.htm">LOC</a> Place/location identification             C   5          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1590">1590</a> + <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdfii.htm">FII</a> Financial institution information         C   5          ��
+                                                                    ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1600">1600</a>       ����� Segment group 36 ������������������ C   5��������Ŀ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1610">1610</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrff.htm">RFF</a> Reference                                 M   1         ���
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1620">1620</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5���������ٳ�
+                                                                    ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1630">1630</a>       ����� Segment group 37 ������������������ C   5��������Ŀ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1640">1640</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddoc.htm">DOC</a> Document/message details                  M   1         ���
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1650">1650</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5���������ٳ�
+                                                                    ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1660">1660</a>       ����� Segment group 38 ������������������ C   5��������Ŀ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1670">1670</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdcta.htm">CTA</a> Contact information                       M   1         ���
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1680">1680</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdcom.htm">COM</a> Communication contact                     C   5����������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1690">1690</a>       ����� Segment group 39 ������������������ C   30��������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1700">1700</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdalc.htm">ALC</a> Allowance or charge                       M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1710">1710</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdali.htm">ALI</a> Additional information                    C   5          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1720">1720</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1730">1730</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdftx.htm">FTX</a> Free text                                 C   1          ��
+                                                                    ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1740">1740</a>       ����� Segment group 40 ������������������ C   1��������Ŀ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1750">1750</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdqty.htm">QTY</a> Quantity                                  M   1         ���
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1760">1760</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrng.htm">RNG</a> Range details                             C   1���������ٳ�
+                                                                    ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1770">1770</a>       ����� Segment group 41 ������������������ C   1��������Ŀ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1780">1780</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdpcd.htm">PCD</a> Percentage details                        M   1         ���
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1790">1790</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrng.htm">RNG</a> Range details                             C   1���������ٳ�
+                                                                    ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1800">1800</a>       ����� Segment group 42 ������������������ C   2��������Ŀ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1810">1810</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmoa.htm">MOA</a> Monetary amount                           M   1         ���
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1820">1820</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrng.htm">RNG</a> Range details                             C   1         ���
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1830">1830</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdcux.htm">CUX</a> Currencies                                C   1         ���
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1840">1840</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   1���������ٳ�
+                                                                    ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1850">1850</a>       ����� Segment group 43 ������������������ C   1��������Ŀ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1860">1860</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrte.htm">RTE</a> Rate details                              M   1         ���
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1870">1870</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrng.htm">RNG</a> Range details                             C   1���������ٳ�
+                                                                    ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1880">1880</a>       ����� Segment group 44 ������������������ C   5��������Ŀ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1890">1890</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdtax.htm">TAX</a> Duty/tax/fee details                      M   1         ���
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1900">1900</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmoa.htm">MOA</a> Monetary amount                           C   2����������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1910">1910</a>       ����� Segment group 45 ������������������ C   10��������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1920">1920</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdtdt.htm">TDT</a> Details of transport                      M   1          ��
+                                                                    ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1930">1930</a>       ����� Segment group 46 ������������������ C   10�������Ŀ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1940">1940</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdloc.htm">LOC</a> Place/location identification             M   1         ���
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1950">1950</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5����������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1960">1960</a>       ����� Segment group 47 ������������������ C   5���������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1970">1970</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdtod.htm">TOD</a> Terms of delivery or transport            M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1980">1980</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdloc.htm">LOC</a> Place/location identification             C   2����������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#1990">1990</a>       ����� Segment group 48 ������������������ C   100�������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2000">2000</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrcs.htm">RCS</a> Requirements and conditions               M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2010">2010</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrff.htm">RFF</a> Reference                                 C   5          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2020">2020</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2030">2030</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdftx.htm">FTX</a> Free text                                 C   5����������ٳ
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2040">2040</a>       ����� Segment group 49 ������������������ C   10��������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2050">2050</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdgis.htm">GIS</a> General indicator                         M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2060">2060</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrff.htm">RFF</a> Reference                                 C   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2070">2070</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2080">2080</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdgir.htm">GIR</a> Related identification numbers            C   5          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2090">2090</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdloc.htm">LOC</a> Place/location identification             C   2          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2100">2100</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmea.htm">MEA</a> Measurements                              C   5          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2110">2110</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdqty.htm">QTY</a> Quantity                                  C   2          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2120">2120</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdftx.htm">FTX</a> Free text                                 C   5          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2130">2130</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmoa.htm">MOA</a> Monetary amount                           C   2������������
+
+           SUMMARY SECTION
+
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2140">2140</a>   <a href="http://www.gefeg.com/jswg/">UNS</a> Section control                           M   1     
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2150">2150</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdcnt.htm">CNT</a> Control total                             C   10    
+
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2160">2160</a>       ����� Segment group 50 ������������������ M   100��������Ŀ
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2170">2170</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmoa.htm">MOA</a> Monetary amount                           M   1           �
+                                                                     �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2180">2180</a>       ����� Segment group 51 ������������������ C   1���������Ŀ�
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2190">2190</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdrff.htm">RFF</a> Reference                                 M   1          ��
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2200">2200</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsddtm.htm">DTM</a> Date/time/period                          C   5������������
+
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2210">2210</a>       ����� Segment group 52 ������������������ C   10���������Ŀ
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2220">2220</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdtax.htm">TAX</a> Duty/tax/fee details                      M   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2230">2230</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmoa.htm">MOA</a> Monetary amount                           C   2������������
+
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2240">2240</a>       ����� Segment group 53 ������������������ C   15���������Ŀ
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2250">2250</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdalc.htm">ALC</a> Allowance or charge                       M   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2260">2260</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdali.htm">ALI</a> Additional information                    C   1           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2270">2270</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdmoa.htm">MOA</a> Monetary amount                           C   2           �
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2280">2280</a>   <a href="https://service.unece.org/trade/untdid/d99a/trsd/trsdftx.htm">FTX</a> Free text                                 C   1������������
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_d.htm#2290">2290</a>   <a href="http://www.gefeg.com/jswg/">UNT</a> Message trailer                           M   1     
+<hr>
+<a href="https://service.unece.org/trade/untdid/d99a/trmd/invoic_c.htm">Contents of INVOIC</a>
+</pre>
+
+</body></html>

--- a/spec/legacyMessageStructureParser.spec.ts
+++ b/spec/legacyMessageStructureParser.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * @author Stefan Partheymüller
+ * @copyright 2021 Stefan Partheymüller
+ * @license Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import { UNECELegacyMessageStructureParser } from "../src/edi/legacyMessageStructureParser";
+import { EdifactMessageSpecificationImpl, EdifactMessageSpecification } from "../src/edi/messageStructureParser";
+import { MessageType } from "../src/tracker";
+
+const D99A_INVOIC_METADATA_PAGE: string = `
+<HTML><PRE><body bgcolor=ffffff><TITLE>UNTDID - D.99A - Message INVOIC</title>
+<! --- This document was created by Viorel Iordache - UN/ECE ----->
+                              UN/EDIFACT
+
+                UNITED NATIONS STANDARD MESSAGE (UNSM)
+
+                            <B>Invoice message</B>
+
+
+                                            Message Type : <B>INVOIC</B>
+                                            Version      : D
+                                            Release      : 99A
+                                            Contr. Agency: UN
+
+                                            Revision     : 10
+                                            Date         : 99-01-14
+
+SOURCE: Joint Rapporteurs Message Design Group JM2
+
+
+
+                               <B>CONTENTS</B>
+
+0.   <A HREF="invoic_d.htm#INTRODUCTION">INTRODUCTION</A>
+
+1.   <A HREF="invoic_d.htm#SCOPE">SCOPE</A>
+
+     1.1   <A HREF="invoic_d.htm#FUNDEF">Functional definition</A>
+     1.2   <A HREF="invoic_d.htm#FOA">Field of application</A>
+     1.3   <A HREF="invoic_d.htm#PRINCIP">Principles</A>
+
+2.   <A HREF="invoic_d.htm#REF">REFERENCES</A>
+
+3.   <A HREF="invoic_d.htm#TAD">TERMS AND DEFINITIONS</A>
+
+     3.1   <A HREF="invoic_d.htm#TAD1">Standard terms and definitions</A>
+
+4.   <A HREF="invoic_d.htm#MESDEF">MESSAGE DEFINITION</A>
+
+     4.1   <A HREF="invoic_d.htm#DSC">Data segment clarification</A>
+           4.1.1 <A HREF="invoic_d.htm#HS">Header section</A>
+           4.1.2 <A HREF="invoic_d.htm#DS">Detail section</A>
+           4.1.3 <A HREF="invoic_d.htm#SS">Summary section</A>
+     4.2   <A HREF="invoic_d.htm#DSGI">Data segment index</A>(alphabetical sequence)
+     4.3   <A HREF="invoic_s.htm">Message structure</A>
+           4.3.1 <A HREF="invoic_s.htm">Segment table</A>
+<A HREF="stand_1.htm">Standard text</A>
+<hr>
+
+</html>
+`;
+
+const D99A_INVOIC_STRUCTURE_PAGE: string =
+    readFileSync(join(__dirname, 'data', 'd99a_invoic_s.html'), 'utf-8');
+
+describe('UNECELegacyMessageStructureParser', () => {
+
+    let sut: UNECELegacyMessageStructureParser;
+
+    const expectedBGMEntry: MessageType = {
+        content: "BGM",
+        mandatory: true,
+        repetition: 1,
+        data: undefined,
+        section: "header"
+    };
+
+    const expectedSegmentGroup27Entry: MessageType = {
+        name: "Segment group 27",
+        content: [
+            { content: "MOA", mandatory: true, repetition: 1, data: undefined, section: undefined },
+            { content: "CUX", mandatory: false, repetition: 1, data: undefined, section: undefined }
+        ],
+        mandatory: false,
+        repetition: 99,
+        data: undefined,
+        section: undefined
+    };
+
+    const expectedUNSEntry: MessageType = {
+        content: "UNS",
+        mandatory: true,
+        repetition: 1,
+        data: undefined,
+        section: "summary"
+    };
+
+    beforeAll(() => {
+        sut = new UNECELegacyMessageStructureParser('D99A', 'INVOIC');
+    });
+
+    describe('parseMetaDataPage', () => {
+
+        it("should extract meta data correctly from D99A INVOIC meta data page", () => {
+            const expectedSpec: EdifactMessageSpecificationImpl =
+                new EdifactMessageSpecificationImpl('INVOIC', 'D', '99A', 'UN');
+
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            const spec: EdifactMessageSpecificationImpl = (sut as any).parseMetaDataPage(D99A_INVOIC_METADATA_PAGE);
+            expect(spec).toEqual(expectedSpec);
+        });
+
+    });
+
+    describe('parseStructurePage', () => {
+
+        it("should extract message structure correctly from D99A INVOIC structure page", () => {
+
+            const spec: EdifactMessageSpecification =
+                new EdifactMessageSpecificationImpl('INVOIC', 'D', '99A', 'UN');
+
+            sut.parseStructurePage(D99A_INVOIC_STRUCTURE_PAGE, spec);
+
+            expect(spec.messageStructureDefinition).toContain(expectedBGMEntry);
+            expect(spec.messageStructureDefinition).toContain(expectedUNSEntry);
+            const sg26: MessageType | undefined =
+                spec.messageStructureDefinition.find(item => item.name === 'Segment group 26');
+            expect(sg26).toBeDefined();
+            expect((sg26 as any).content).toContain(expectedSegmentGroup27Entry);
+        });
+
+    });
+
+    describe('loadTypeSpec', () => {
+
+        it("should parse remote UNECE specification", async () => {
+            const spec: EdifactMessageSpecification = await sut.loadTypeSpec();
+            expect(spec.controllingAgency).toBe('UN');
+            expect(spec.version).toBe('D');
+            expect(spec.release).toBe('99A');
+            expect(spec.messageType).toBe('INVOIC');
+            expect(spec.messageStructureDefinition).toContain(expectedBGMEntry);
+            expect(spec.messageStructureDefinition).toContain(expectedUNSEntry);
+            const sg26: MessageType | undefined =
+                spec.messageStructureDefinition.find(item => item.name === 'Segment group 26');
+            expect(sg26).toBeDefined();
+            expect((sg26 as any).content).toContain(expectedSegmentGroup27Entry);
+        });
+
+    });
+
+});

--- a/src/edi/legacyMessageStructureParser.ts
+++ b/src/edi/legacyMessageStructureParser.ts
@@ -16,33 +16,15 @@
  * limitations under the License.
  */
 
-import { HttpClient } from "../httpClient";
 import {
     EdifactMessageSpecification,
-    MessageStructureParser,
-    ParsingResultType
+    ParsingResultType,
+    UNECEMessageStructureParser
 } from "./messageStructureParser";
 import { UNECEMetaDataPageParser } from './uneceMetaDataPageParser';
 import { UNECEStructurePageParser } from './uneceStructurePageParser';
 
-export class UNECELegacyMessageStructureParser implements MessageStructureParser {
-
-    private version: string;
-    private type: string;
-    private httpClient: HttpClient;
-
-    constructor(version: string, type: string) {
-        this.version = version.toLowerCase();
-        this.type = type.toLowerCase();
-
-        const baseUrl: string = "https://service.unece.org/trade/untdid/" + this.version + "/trmd/" + this.type + "_c.htm";
-        this.httpClient = new HttpClient(baseUrl);
-    }
-
-    private async loadPage(page: string): Promise<string> {
-        const data: string = await this.httpClient.get(page);
-        return data;
-    }
+export class UNECELegacyMessageStructureParser extends UNECEMessageStructureParser {
 
     parseMetaDataPage(page: string): EdifactMessageSpecification {
         const parser: UNECEMetaDataPageParser = new UNECEMetaDataPageParser();
@@ -76,4 +58,5 @@ export class UNECELegacyMessageStructureParser implements MessageStructureParser
                     })
             );
     }
+
 }

--- a/src/edi/legacyMessageStructureParser.ts
+++ b/src/edi/legacyMessageStructureParser.ts
@@ -1,0 +1,79 @@
+/**
+ * @author Stefan Partheymüller
+ * @copyright 2021 Stefan Partheymüller
+ * @license Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HttpClient } from "../httpClient";
+import {
+    EdifactMessageSpecification,
+    MessageStructureParser,
+    ParsingResultType
+} from "./messageStructureParser";
+import { UNECEMetaDataPageParser } from './uneceMetaDataPageParser';
+import { UNECEStructurePageParser } from './uneceStructurePageParser';
+
+export class UNECELegacyMessageStructureParser implements MessageStructureParser {
+
+    private version: string;
+    private type: string;
+    private httpClient: HttpClient;
+
+    constructor(version: string, type: string) {
+        this.version = version.toLowerCase();
+        this.type = type.toLowerCase();
+
+        const baseUrl: string = "https://service.unece.org/trade/untdid/" + this.version + "/trmd/" + this.type + "_c.htm";
+        this.httpClient = new HttpClient(baseUrl);
+    }
+
+    private async loadPage(page: string): Promise<string> {
+        const data: string = await this.httpClient.get(page);
+        return data;
+    }
+
+    parseMetaDataPage(page: string): EdifactMessageSpecification {
+        const parser: UNECEMetaDataPageParser = new UNECEMetaDataPageParser();
+        parser.parse(page);
+        return parser.spec;
+    }
+
+    parseStructurePage(page: string, spec: EdifactMessageSpecification): void {
+        const parser: UNECEStructurePageParser = new UNECEStructurePageParser(spec);
+        parser.parse(page);
+    }
+
+    loadTypeSpec(): Promise<EdifactMessageSpecification> {
+        const url: string = "./" + this.type + "_c.htm";
+        return this.loadPage(url)
+            .then(async (metaDataPage: string) => {
+                const spec: EdifactMessageSpecification = this.parseMetaDataPage(metaDataPage);
+                const structurePage: string = await this.loadPage(`./${this.type}_s.htm`);
+                this.parseStructurePage(structurePage, spec);
+                return {
+                    specObj: spec,
+                    promises: []
+                };
+            })
+            .then((result: ParsingResultType) =>
+                Promise.all(result.promises)
+                    .then(() => result.specObj)
+                    .catch((error: Error) => {
+                        console.warn(`Error while processing segment definition promises: Reason ${error.message}`);
+                        return result.specObj;
+                    })
+            );
+    }
+}

--- a/src/edi/messageStructureParser.ts
+++ b/src/edi/messageStructureParser.ts
@@ -47,7 +47,7 @@ export interface EdifactMessageSpecification {
     versionAbbr(): string;
 }
 
-class EdifactMessageSpecificationImpl implements EdifactMessageSpecification {
+export class EdifactMessageSpecificationImpl implements EdifactMessageSpecification {
 
     messageType: string;
     version: string;

--- a/src/edi/messageStructureParser.ts
+++ b/src/edi/messageStructureParser.ts
@@ -102,9 +102,9 @@ export interface MessageStructureParser {
 
 export class UNECEMessageStructureParser implements MessageStructureParser {
 
-    private version: string;
-    private type: string;
-    private httpClient: HttpClient;
+    readonly version: string;
+    readonly type: string;
+    readonly httpClient: HttpClient;
 
     constructor(version: string, type: string) {
         this.version = version.toLowerCase();
@@ -112,11 +112,6 @@ export class UNECEMessageStructureParser implements MessageStructureParser {
 
         const baseUrl: string = "https://service.unece.org/trade/untdid/" + this.version + "/trmd/" + this.type + "_c.htm";
         this.httpClient = new HttpClient(baseUrl);
-    }
-
-    private async loadPage(page: string): Promise<string> {
-        const data: string = await this.httpClient.get(page);
-        return data;
     }
 
     private extractTextValue(text: string, regex: RegExp, index: number = 0): string {
@@ -127,7 +122,12 @@ export class UNECEMessageStructureParser implements MessageStructureParser {
         return "";
     }
 
-    private async parseSegmentDefinitionPage(segment: string, page: string, definition: EdifactMessageSpecification): Promise<EdifactMessageSpecification> {
+    protected async loadPage(page: string): Promise<string> {
+        const data: string = await this.httpClient.get(page);
+        return data;
+    }
+
+    protected async parseSegmentDefinitionPage(segment: string, page: string, definition: EdifactMessageSpecification): Promise<EdifactMessageSpecification> {
         if (definition.segmentTable.contains(segment)) {
             return Promise.resolve(definition);
         }

--- a/src/edi/messageStructureParser.ts
+++ b/src/edi/messageStructureParser.ts
@@ -110,7 +110,7 @@ export class UNECEMessageStructureParser implements MessageStructureParser {
         this.version = version.toLowerCase();
         this.type = type.toLowerCase();
 
-        const baseUrl: string = "https://www.unece.org/trade/untdid/" + this.version + "/trmd/" + this.type + "_c.htm";
+        const baseUrl: string = "https://service.unece.org/trade/untdid/" + this.version + "/trmd/" + this.type + "_c.htm";
         this.httpClient = new HttpClient(baseUrl);
     }
 

--- a/src/edi/uneceMetaDataPageParser.ts
+++ b/src/edi/uneceMetaDataPageParser.ts
@@ -1,0 +1,92 @@
+/**
+ * @author Stefan Partheymüller
+ * @copyright 2021 Stefan Partheymüller
+ * @license Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { StateMachineDefinition } from "@initics/tsm";
+import { DomHandler } from "htmlparser2";
+
+import { EdifactMessageSpecificationImpl } from "./messageStructureParser";
+import { UNECEPageParser } from "./unecePageParser";
+
+enum State {
+    initial = 'initial',
+    beforeMessageType = 'beforeMessageType',
+    afterMessageType = 'afterMessageType',
+    beforeMetaData = 'beforeMetaData',
+    afterMetaData = 'afterMetaData'
+}
+
+const SM_DEFINITION: StateMachineDefinition = {
+    initial: State.initial,
+    transitions: [
+        { from: State.initial, to: State.beforeMessageType },
+        { from: State.beforeMessageType, to: State.afterMessageType },
+        { from: State.afterMessageType, to: State.beforeMetaData },
+        { from: State.beforeMetaData, to: State.afterMetaData }
+    ]
+};
+
+export class UNECEMetaDataPageParser extends UNECEPageParser {
+
+    private messageType?: string;
+
+    constructor() {
+        super(SM_DEFINITION);
+    }
+
+    protected setupHandler(): DomHandler {
+        const handler: DomHandler = super.setupHandler();
+
+        handler.ontext = (text: string) => {
+            switch (this.sm.state) {
+                case State.initial:
+                    if (text.includes('Message Type')) {
+                        this.sm.transition(State.beforeMessageType);
+                    }
+                    break;
+
+                case State.beforeMessageType:
+                    this.messageType = text;
+                    this.sm.transition(State.afterMessageType);
+                    break;
+
+                case State.afterMessageType:
+                    if (!this.messageType) {
+                        this.throwCouldNotParsePage();
+                    } else {
+                        if (text.includes('Version') && text.includes('Release') && text.includes('Contr. Agency')) {
+                            const version: string = this.extractTextValue(text, /Version\s*: ([A-Z]*)\s/g, 1);
+                            const release: string = this.extractTextValue(text, /Release\s*: ([0-9A-Z]*)\s/g, 1);
+                            const controllingAgency: string = this.extractTextValue(text, /Contr. Agency\s*: ([0-9A-Z]*)\s/g, 1);
+                            this._spec = new EdifactMessageSpecificationImpl(
+                                this.messageType,
+                                version,
+                                release,
+                                controllingAgency
+                            );
+                        }
+                    }
+                    break;
+
+                default: this.throwInvalidParserState(this.sm.state);
+            }
+        };
+
+        return handler;
+    }
+
+}

--- a/src/edi/unecePageParser.ts
+++ b/src/edi/unecePageParser.ts
@@ -1,0 +1,68 @@
+/**
+ * @author Stefan Partheymüller
+ * @copyright 2021 Stefan Partheymüller
+ * @license Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Parser, DomHandler } from "htmlparser2";
+import { StateMachine, StateMachineDefinition } from "@initics/tsm";
+
+import { isDefined } from "../util";
+import { EdifactMessageSpecification } from "./messageStructureParser";
+
+export abstract class UNECEPageParser {
+
+    protected sm: StateMachine;
+    protected _spec?: EdifactMessageSpecification;
+
+    constructor(smdef: StateMachineDefinition) {
+        this.sm = new StateMachine(smdef);
+    }
+
+    get spec(): EdifactMessageSpecification {
+        const spec: EdifactMessageSpecification | undefined = this._spec;
+        if (!spec) {
+            throw new Error(`EdifactMessageSpecification not defined`);
+        }
+        return spec;
+    }
+
+    parse(page: string): void {
+        const parser: Parser = new Parser(this.setupHandler());
+        parser.write(page);
+        parser.end();
+    }
+
+    protected setupHandler(): DomHandler {
+        return new DomHandler();
+    }
+
+    protected extractTextValue(text: string, regex: RegExp, index: number = 0): string {
+        const arr: RegExpExecArray | null = regex.exec(text);
+        if (isDefined(arr)) {
+            return arr[index];
+        }
+        return "";
+    }
+
+    protected throwInvalidParserState(state: string): void {
+        throw new Error(`Invalid parser state: ${state}`);
+    }
+
+    protected throwCouldNotParsePage(): void {
+        throw new Error('Could not parse page');
+    }
+
+}

--- a/src/edi/unecePageParser.ts
+++ b/src/edi/unecePageParser.ts
@@ -32,11 +32,10 @@ export abstract class UNECEPageParser {
     }
 
     get spec(): EdifactMessageSpecification {
-        const spec: EdifactMessageSpecification | undefined = this._spec;
-        if (!spec) {
+        if (!this._spec) {
             throw new Error(`EdifactMessageSpecification not defined`);
         }
-        return spec;
+        return this._spec;
     }
 
     parse(page: string): void {

--- a/src/edi/uneceStructurePageParser.ts
+++ b/src/edi/uneceStructurePageParser.ts
@@ -1,0 +1,211 @@
+/**
+ * @author Stefan Partheymüller
+ * @copyright 2021 Stefan Partheymüller
+ * @license Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { StateMachineDefinition } from "@initics/tsm";
+import { DomHandler } from "htmlparser2";
+import { MessageType } from "../tracker";
+
+import { EdifactMessageSpecification } from "./messageStructureParser";
+import { UNECEPageParser } from "./unecePageParser";
+
+enum State {
+    initial = 'initial',
+    messageStructureStart = 'messageStructureStart',
+    messageStructureEnd = 'messageStructureEnd',
+    headerSection = 'headerSection',
+    detailSection = 'detailSection',
+    summarySection = 'summarySection',
+    beforeDetailSection = 'beforeDetailSection',
+    segmentPosition = 'segmentPosition',
+    segmentGroup = 'segmentGroup',
+    segmentName = 'segmentName',
+    segmentDescription = 'segmentDescription',
+}
+
+const SM_DEFINITION: StateMachineDefinition = {
+    initial: State.initial,
+    transitions: [
+        { from: State.initial, to: State.messageStructureStart },
+        { from: State.messageStructureStart, to: State.headerSection },
+        { from: State.headerSection, to: State.segmentPosition },
+        { from: State.detailSection, to: State.segmentPosition },
+        { from: State.summarySection, to: State.segmentPosition },
+        { from: State.segmentPosition, to: State.segmentGroup },
+        { from: State.segmentPosition, to: State.messageStructureEnd },
+        { from: State.segmentGroup, to: State.segmentName },
+        { from: State.segmentGroup, to: State.segmentPosition },
+        { from: State.segmentName, to: State.segmentDescription },
+        { from: State.segmentDescription, to: State.segmentPosition },
+        { from: State.segmentDescription, to: State.detailSection },
+        { from: State.segmentDescription, to: State.summarySection }
+    ]
+};
+
+export class UNECEStructurePageParser extends UNECEPageParser {
+
+    constructor(spec: EdifactMessageSpecification) {
+        super(SM_DEFINITION);
+        this._spec = spec;
+    }
+
+    protected setupHandler(): DomHandler {
+        const helper: DomHandler = super.setupHandler();
+
+        let index: number = 0;
+        const stack: MessageType[][] = [];
+        let section: string | undefined;
+        let name: string;
+
+        helper.ontext = (text: string) => {
+            switch (this.sm.state) {
+                case State.initial:
+                    if (text.includes('Message structure')) {
+                        this.sm.transition(State.messageStructureStart);
+                    }
+                    break;
+
+                case State.messageStructureStart:
+                    if (text.includes('HEADER SECTION')) {
+                        stack.push(this.spec.messageStructureDefinition);
+                        this.sm.transition(State.headerSection);
+                        section = 'header';
+                        this.sm.transition(State.segmentPosition);
+                    }
+                    break;
+
+                case State.segmentPosition:
+                    if (text.match(/[0-9]{4}/g)) {
+                        this.sm.transition(State.segmentGroup);
+                    } else {
+                        this.sm.transition(State.messageStructureEnd);
+                    }
+                    break;
+
+                case State.segmentGroup:
+                    if (text.includes('Segment group')) {
+                        const group: MessageType = this.parseSegmentGroup(section, text);
+                        const level: number = this.parseSegmentGroupLevel(text);
+                        const delta: number = level - index;
+                        if (delta <= 0) {
+                            for (let i: number = 0; i < (delta * -1 + 1); i++) {
+                                stack.pop();
+                                index--;
+                            }
+                        }
+
+                        stack[index].push(group);
+                        stack.push(group.content as []);
+                        index++;
+
+                        // reset section assignment after first segment group
+                        section = undefined;
+
+                        this.sm.transition(State.segmentPosition);
+                    } else {
+                        this.sm.transition(State.segmentName);
+                    }
+                    break;
+
+                case State.segmentName:
+                    name = text;
+                    this.sm.transition(State.segmentDescription);
+                    break;
+
+                case State.segmentDescription: {
+                    const item: MessageType = this.parseSegment(name, section, text);
+                    stack[index].push(item);
+
+                    const detailSection: boolean = text.includes('DETAIL SECTION');
+                    const summarySection: boolean = text.includes('SUMMARY SECTION');
+                    if (detailSection || summarySection) {
+                        for (; index > 0; index--) {
+                            stack.pop();
+                        }
+                        if (detailSection) {
+                            section = 'detial';
+                            this.sm.transition(State.detailSection);
+                        } else {
+                            section = 'summary';
+                            this.sm.transition(State.summarySection);
+                        }
+                    }
+
+                    this.sm.transition(State.segmentPosition);
+                    break;
+                }
+
+                case State.messageStructureEnd: break;
+
+                default: this.throwInvalidParserState(this.sm.state);
+            }
+        };
+
+        return helper;
+    }
+
+    private parseSegmentGroup(section: string | undefined, descriptionString: string): MessageType {
+        const regex: RegExp = /^.* (Segment group \d*).*\s*([M|C])\s*(\d*).*/g;
+        const matches: RegExpExecArray | null = regex.exec(descriptionString);
+        if (!matches) {
+            throw new Error('Invalid segment description string');
+        }
+
+        const name: string = matches[1];
+        const mandatoryString: string = matches[2];
+        const repetitionString: string = matches[3];
+
+        return {
+            name,
+            content: [],
+            mandatory: mandatoryString === 'M',
+            repetition: Number.parseInt(repetitionString),
+            data: undefined,
+            section: section || undefined
+        };
+    }
+
+    private parseSegment(name: string, section: string | undefined, descriptionString: string): MessageType {
+        const regex: RegExp = /^([a-zA-Z /\\-]*)\s*?([M|C])\s*?([0-9]*?)([^0-9]*)$/g;
+        const matches: RegExpExecArray | null = regex.exec(descriptionString);
+        if (!matches) {
+            throw new Error('Invalid segment description string');
+        }
+
+        const mandatoryString: string = matches[2];
+        const repetitionString: string = matches[3];
+
+        return {
+            content: name,
+            mandatory: mandatoryString === 'M',
+            repetition: Number.parseInt(repetitionString),
+            data: undefined,
+            section: section || undefined
+        };
+    }
+
+    private parseSegmentGroupLevel(descriptionString: string): number {
+        const regex: RegExp = /^.*[0-9]+([^0-9]*)$/g;
+        const matches: RegExpExecArray | null = regex.exec(descriptionString);
+        if (!matches) {
+            throw new Error('Invalid segment description string');
+        }
+        const levelString: string = Array.from(matches[1]).reverse().join('');
+        return levelString.indexOf('Ŀ');
+    }
+
+}

--- a/src/edi/uneceStructurePageParser.ts
+++ b/src/edi/uneceStructurePageParser.ts
@@ -58,9 +58,12 @@ const SM_DEFINITION: StateMachineDefinition = {
 
 export class UNECEStructurePageParser extends UNECEPageParser {
 
+    readonly segmentNames: string[];
+
     constructor(spec: EdifactMessageSpecification) {
         super(SM_DEFINITION);
         this._spec = spec;
+        this.segmentNames = [];
     }
 
     protected setupHandler(): DomHandler {
@@ -123,6 +126,7 @@ export class UNECEStructurePageParser extends UNECEPageParser {
 
                 case State.segmentName:
                     name = text;
+                    this.addSegmentName(name);
                     this.sm.transition(State.segmentDescription);
                     break;
 
@@ -156,6 +160,17 @@ export class UNECEStructurePageParser extends UNECEPageParser {
         };
 
         return helper;
+    }
+
+    private addSegmentName(name: string): void {
+        const excludeSegmentNames: string[] = [
+            'UNH',
+            'UNS',
+            'UNT'
+        ];
+        if (!excludeSegmentNames.includes(name) && !this.segmentNames.includes(name)) {
+            this.segmentNames.push(name);
+        }
     }
 
     private parseSegmentGroup(section: string | undefined, descriptionString: string): MessageType {


### PR DESCRIPTION
The current version of `UNECEMessageStructureParser` class did not support parsing legacy (up to version D99A) message specifications.
I created a new class `UNECELegacyMessageStructureParser`, that supports the legacy message specifications (see unit tests).