### PR TITLE
chore(dependencies): update axios to prevent known vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
             "webpack-cli": "^3.3.12"
       },
       "dependencies": {
-            "axios": "0.19.2"
+            "axios": "0.21.1"
       },
       "files": [
             "lib/**/*"


### PR DESCRIPTION
Hey! This PR updates the `axios` dependency to the latest version `0.21.1` to mitigate the risk for open vulnerabilities.
In particular this version update fixes https://www.npmjs.com/advisories/1594.